### PR TITLE
Welcome: rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,7 @@
+# Allow japanese comments
+Style/AsciiComments:
+  Enabled: false
+
+# Prefer double quoted string literals
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 brew "rbenv"
 brew "google-chrome"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
 gem 'selenium-webdriver'
 gem 'webdrivers'
+
+group :development do
+  gem 'rubocop', require: false
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
-source 'https://rubygems.org'
-gem 'selenium-webdriver'
-gem 'webdrivers'
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gem "selenium-webdriver"
+gem "webdrivers"
 
 group :development do
-  gem 'rubocop', require: false
+  gem "rubocop", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,29 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.0)
     childprocess (3.0.0)
+    jaro_winkler (1.5.4)
     mini_portile2 (2.4.0)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
+    parallel (1.19.1)
+    parser (2.7.0.2)
+      ast (~> 2.4.0)
+    rainbow (3.0.0)
+    rubocop (0.79.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    ruby-progressbar (1.10.1)
     rubyzip (2.0.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    unicode-display_width (1.6.1)
     webdrivers (4.2.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -18,6 +33,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  rubocop
   selenium-webdriver
   webdrivers
 

--- a/README.md
+++ b/README.md
@@ -14,3 +14,17 @@ bundle
 ```sh
 bundle exec ruby dmm.rb HogeLoginID HogePassword
 ```
+
+# Development
+
+Run Lint.
+
+```sh
+bundle exec rubocop
+```
+
+or auto correct.
+
+```sh
+bundle exec rubocop --auto-correct
+```

--- a/dmm.rb
+++ b/dmm.rb
@@ -33,8 +33,8 @@ driver.find_element(:id, "password").send_keys(PASSWORD)
 driver.find_element(:class, "btn-login").click # classでの指定
 
 message = catch(:success) do
-  [true, false].each do |isFavorite|
-    puts isFavorite
+  [true, false].each do |is_favorite|
+    puts is_favorite
 
     ALLOWTIMES.each do |time|
       puts time

--- a/dmm.rb
+++ b/dmm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "webdrivers"
 require "uri"
 
@@ -5,20 +7,20 @@ LOGINID =  ARGV[0] || ENV["DMMLOGINID"]
 PASSWORD = ARGV[1] || ENV["DMMPASSWORD"]
 
 ALLOWTIMES = [
-    "22:00",
-    "22:30",
-    "23:00",
-    "23:30",
-    "24:00",
-    "24:30",
-]
+  "22:00",
+  "22:30",
+  "23:00",
+  "23:30",
+  "24:00",
+  "24:30"
+].freeze
 
 TAB_1 = "&data[tab1]"
 
 ENV["TZ"] = "Asia/Tokyo"
 
 now = Time.new
-date =  "#{now.year}-#{now.month}-#{now.day}"
+date = "#{now.year}-#{now.month}-#{now.day}"
 sort = 6
 native = 1
 favorite = "on"
@@ -28,52 +30,52 @@ driver.navigate.to "https://accounts.dmm.com/service/login/password"
 
 driver.find_element(:id, "login_id").send_keys(LOGINID)
 driver.find_element(:id, "password").send_keys(PASSWORD)
-driver.find_element(:class, "btn-login").click() # classでの指定
+driver.find_element(:class, "btn-login").click # classでの指定
 
 message = catch(:success) do
-    [true, false].each do |isFavorite|
-        puts isFavorite
+  [true, false].each do |isFavorite|
+    puts isFavorite
 
-        ALLOWTIMES.each do |time|
-            puts time
+    ALLOWTIMES.each do |time|
+      puts time
 
-            url_string = [
-                "https://eikaiwa.dmm.com/",
-                "list/?",
-                TAB_1,
-                "[start_time]=",
-                time,
-                TAB_1,
-                "[end_time]=",
-                time,
-                TAB_1,
-                "[native]=",
-                native,
-                TAB_1,
-                "[favorite]=",
-                favorite,
-                "&date=",
-                date,
-                "&sort=",
-                sort,
-            ].join
+      url_string = [
+        "https://eikaiwa.dmm.com/",
+        "list/?",
+        TAB_1,
+        "[start_time]=",
+        time,
+        TAB_1,
+        "[end_time]=",
+        time,
+        TAB_1,
+        "[native]=",
+        native,
+        TAB_1,
+        "[favorite]=",
+        favorite,
+        "&date=",
+        date,
+        "&sort=",
+        sort
+      ].join
 
-            puts url_string
+      puts url_string
 
-            # Note:
-            # This API was obsolete.
-            # https://docs.ruby-lang.org/ja/latest/method/URI/s/encode.html
-            url = URI.encode(url_string)
+      # Note:
+      # This API was obsolete.
+      # https://docs.ruby-lang.org/ja/latest/method/URI/s/encode.html
+      url = URI.encode(url_string)
 
-            driver.navigate().to url
-            buttons = driver.find_elements(:class, "bt-open").select(&:displayed?)
+      driver.navigate.to url
+      buttons = driver.find_elements(:class, "bt-open").select(&:displayed?)
 
-            buttons.each do |button|
-                button.click()
-                sleep(3)
-                driver.find_element(:id, "submitBox").click()
-                throw :success, "OK"
-            end
-        end
+      buttons.each do |button|
+        button.click
+        sleep(3)
+        driver.find_element(:id, "submitBox").click
+        throw :success, "OK"
+      end
     end
+  end
 end


### PR DESCRIPTION
噂の [rubocop](https://github.com/rubocop-hq/rubocop) を導入してみました。

Rubyは（4スペースではなく）2スペースが標準的で、空白系の修正が多く出ているので`?w=1`を末尾に付けた状態でのレビューがオススメです。
https://github.com/po-miyasaka/AutoReserve/pull/4/files?w=1

## TODO
- [x] rubocop の導入
  - [x] `.rubocop.yml`の追加
- [x] 修正
  - [x] `--auto-correct`で自動修正
  - [x] 変数をスネークケースで統一
- [x] README更新

## 備考
現時点で実行すると、自動修正（`--auto-correct`）が不可能な3つのルール（計5箇所）が警告されます。

- Lint/UselessAssignment
  - 未使用の変数
- Metrics/BlockLength
  - ブロック内の行数が多すぎる
- Lint/UriEscapeUnescape
  - `URI.encode`が obsolete

```sh
$ bundle exec rubocop                                             
Inspecting 3 files
..W

Offenses:

dmm.rb:35:1: W: Lint/UselessAssignment: Useless assignment to variable - message.
message = catch(:success) do
^^^^^^^
dmm.rb:35:11: C: Metrics/BlockLength: Block has too many lines. [36/25]
message = catch(:success) do ...
          ^^^^^^^^^^^^^^^^^^
dmm.rb:36:3: C: Metrics/BlockLength: Block has too many lines. [34/25]
  [true, false].each do |is_favorite| ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
dmm.rb:39:5: C: Metrics/BlockLength: Block has too many lines. [31/25]
    ALLOWTIMES.each do |time| ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^
dmm.rb:68:13: W: Lint/UriEscapeUnescape: URI.encode method is obsolete and should not be used. Instead, use CGI.escape, URI.encode_www_form or URI.encode_www_form_component depending on y
our specific use case.
      url = URI.encode(url_string)
            ^^^^^^^^^^^^^^^^^^^^^^

3 files inspected, 5 offenses detected
```