### PR TITLE
Rubocop's auto correct by GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,31 @@ jobs:
           bundler-${{ hashFiles('Gemfile.lock') }}
 
     - name: Setup
-      run: bundle
+      run: |
+        bundle
 
+    # Note:
+    # Run only PR in own repository.
+    # Because can't push to forked repository.
+    - name: Run rubocop --auto-correct and push
+      if: contains(github.event.pull_request.head.repo.clone_url, github.repository)
+      run: |
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+        git config --global user.name 'Yusuke Hosonuma'
+        git config --global user.email '2990285+YusukeHosonuma@users.noreply.github.com'
+        git checkout -b ${{ github.head_ref }} origin/${{ github.head_ref }}
+        bundle exec rubocop --auto-correct && true
+        git add -u
+        git diff-index --quiet HEAD -- || git commit -m '[ci skip] $ rubocop --auto-correct'
+        git push
+
+    # Note:
+    # Run only PR in own repository.
+    # Because can't comment to PR from danger. (Maybe you can... ?)
     - name: Run danger
-      run: bundle exec danger
+      if: contains(github.event.pull_request.head.repo.clone_url, github.repository)
+      run: |
+        bundle exec danger
 
     env:
       DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # rubocop
 #


### PR DESCRIPTION
#5 では danger による Rubocop の指摘だけ行っていましたが、この PR では一歩進めて `rubocop` で自動修正できるものは GitHub Actions で修正・コミット・Push するようにしました。

1. `rubocop --auto-correct`を適用＋自動コミット・Push
2. 自動修正できないものは PR へコメント（ #5 と同様）

ただ、両方とも **Fork されたリポジトリからの PR だと動作しない** ことが分かったので自身のリポジトリ内での PR のときのみ動作するようにしています。

## TODO
- [x] GitHub Actions で`rubocop --auto-correct`＋コミット・Pushを実行
- [x] 動作確認用のダミーコミット（ e373632 ）

## 動作イメージ
以下のような感じで、自動的に修正・コミットされます。
https://github.com/YusukeHosonuma/AutoReserve/pull/5

### コミット履歴
![image](https://user-images.githubusercontent.com/2990285/73624078-bf748a00-4682-11ea-8d30-c600f3dc29c4.png)

### コミット内容
![image](https://user-images.githubusercontent.com/2990285/73624095-d0bd9680-4682-11ea-83ad-f87bbbdde852.png)

##  補足

| [自分のリポジトリ内](https://github.com/YusukeHosonuma/AutoReserve/runs/422370728) | [ForkされたリポジトリからPR](https://github.com/po-miyasaka/AutoReserve/runs/422370320) |
|--------------------|----------------------------|
| ![image](https://user-images.githubusercontent.com/2990285/73624224-50e3fc00-4683-11ea-8a50-7f1d98828417.png) | ![image](https://user-images.githubusercontent.com/2990285/73624257-80930400-4683-11ea-8074-78c4618d8549.png) |