### PR TITLE
Welcome: Rake

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # rubocop
 #

--- a/README.md
+++ b/README.md
@@ -1,36 +1,30 @@
 # AutoReserve
+
 ブラウザを動かして予約するやつ
 
-# Usage
+## Usage
 
-## SetUp
+### SetUp
 
 ```sh
 bundle
 ```
 
-## Run
+### Run
 
 ```sh
 bundle exec ruby dmm.rb HogeLoginID HogePassword
 ```
 
-# Development
+## Development
 
-## Run Lint
+Run `rake` to run Lint (autocorrect) and Test.
 
-```sh
-bundle exec rubocop
-```
-
-or auto correct.
+You can confirm all tasks via `rake -T` that like following.
 
 ```sh
-bundle exec rubocop --auto-correct
-```
-
-## Run RSpec
-
-```sh
-bundle exec rspec
+$ rake -T
+rake lint  # Lint and auto-correct by Rubocop
+rake test  # Run all tests by rspec
+...
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+task default: %w[lint test]
+
+desc "Lint and auto-correct by Rubocop"
+task :lint do
+  system "bundle exec rubocop --auto-correct"
+end
+
+desc "Run all tests by rspec"
+task :test do
+  system "bundle exec rspec"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -11,3 +11,8 @@ desc "Run all tests by rspec"
 task :test do
   system "bundle exec rspec"
 end
+
+desc "Print all specs (not run tests)"
+task :test_doc do
+  system "bundle exec rspec --format documentation --dry-run"
+end


### PR DESCRIPTION
Ruby 標準のビルドツールである [Rake](https://github.com/ruby/rake) を導入しました。

公式ドキュメントにも記載されていますが、Ruby における Make のようなもので、Ruby の構文（DSL）を利用して簡単に記述できるようになっています。

`rake <タスク名>`とするのが基本的な使い方になり、例えば`rake test`を実行すると次のようになります。
![image](https://user-images.githubusercontent.com/2990285/73916101-15099a80-4900-11ea-900b-b420527825b5.png)
