### PR TITLE
CI: run rspec in GitHub Actions

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on: [push]
+
+jobs:
+  build:
+
+    # Note:
+    # Maybe can use linux image
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache bundler
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: bundler-${{ hashFiles('Gemfile.lock') }}
+        restore-keys: |
+          bundler-${{ hashFiles('Gemfile.lock') }}
+
+    - name: Setup
+      run: |
+        bundle
+
+    - name: Run test
+      run: |
+        rake test
+
+    env:
+      DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,4 +1,4 @@
-name: Run danger
+name: Rubocop
 
 on: [pull_request]
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # AutoReserve
 
+[![Test](https://github.com/po-miyasaka/AutoReserve/workflows/Test/badge.svg)](https://github.com/po-miyasaka/AutoReserve/actions?query=workflow%3ATest)
+[![License](https://img.shields.io/github/license/po-miyasaka/AutoReserve)](https://github.com/po-miyasaka/AutoReserve/blob/master/LICENSE)
+[![Twitter](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2Fpo_miyasaka)](https://twitter.com/po_miyasaka)
+
 ブラウザを動かして予約するやつ
 
 ## Usage


### PR DESCRIPTION
GitHub Actions で Rspec も実行するようにしました。

`master`ブランチにマージされた時でも実行されるように、**pushトリガー**で RSpec を実行するワークフロー`rspec.yml`という名前で用意しました。なお、既存のワークフロー名は`rubocop.yml`に名前を変更しています。
![image](https://user-images.githubusercontent.com/2990285/74612764-b89e4a80-514b-11ea-8780-d5796e087d97.png)

ついでに README の見栄えも良くしてみました（気に入らなければ discard で大丈夫です）。
![image](https://user-images.githubusercontent.com/2990285/74612836-880ae080-514c-11ea-98d8-1073ce32e830.png)

## TODO
- [x] `main.yml` -> `rubocop.yml`
- [x] `rspec.yml`の作成（Pushトリガーで Rspec を実行）
- [x] README に各種バッジを追加